### PR TITLE
Clean up styling - alignment & redundant CSS

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -81,6 +81,11 @@ h1 {
 
 .landmark-header, .tour-header {
   align-items: center;
+  display: flex;
+}
+
+.landmark-header h3 {
+  margin-left: 5px;
 }
 
 .inline-block {
@@ -99,7 +104,7 @@ h1 {
   color: blue;
 }
 
-.recording-box {
+.recording-box, .tour-box {
   width: 90%;
   margin-left: 5px;
 }
@@ -107,28 +112,11 @@ h1 {
 .recording-list, .tour-list {
   display: flex;
   align-items: center;
-  background-color: #06D2B9;
+  background-color: #c1e8e4;
   border-radius: 5px;
   border: 1px solid white;
-  margin: 10px;;
-}
-
-.tour-list {
+  margin: 10px;
   padding: 5px;
-  background-color: #06D2B9;
-  color: white;
-}
-
-.tour-box {
-  background-color: #06D2B9;
-  color: white;
-  outline-color: white;
-  font-weight: bold;
-}
-
-.tour-info {
-  color: white;
-  font-weight: bold;
 }
 
 .tour-info:hover {

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -21,8 +21,8 @@
 <% if @user.tours.any? %>
   <% @user.tours.each do |tour| %>
     <div class='tour-list'>
+      <%= render partial: 'shared/voting_arrows', object: tour %>
       <div class='tour-box'>
-        <%= render partial: 'shared/voting_arrows', object: tour %>
         <%= link_to tour.title, tour_path(tour) %>
       </div>
     </div>


### PR DESCRIPTION
**Changes proposed in this pull request:**
 - Cleans up styling by fixing text alignment and removing redundant CSS
 
**The following checks have been completed:**
 - [x] Tested my new feature(s) as well as any feasible edge cases (if possible)
 - [x] Checked `coverage/index.html` - did not add any new code that's not covered by testing (if possible)
 - [x] Merged in the latest master to my branch with `git pull origin master` & resolved merge conflicts
 - [x] Ran `rails db:migrate`
 - [x] Ran the test suite - all tests are passing (or maybe skipped)
 - [x] Poked around in localhost with a small screen size - my new features (as well as basic functionality of the site) are working