### PR TITLE
Tour thumbnail

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -142,6 +142,12 @@ h1 {
   word-break: keep-all;
 }
 
+.tour-thumb {
+  object-fit: cover;
+  width: 100px;
+  height: 100px;
+}
+
 figure {
   margin: 0;
 }

--- a/app/facades/landmarks_show_facade.rb
+++ b/app/facades/landmarks_show_facade.rb
@@ -14,16 +14,10 @@ class LandmarksShowFacade
   end
 
   def picture
-    @_picture ||= google_service.get_picture(landmark.photo_reference)
+    landmark.photo_reference
   end
 
   def landmark_recordings
     landmark.recordings
-  end
-
-  private
-
-  def google_service
-    @_google_service ||= GoogleService.new
   end
 end

--- a/app/facades/tour_landmark_show_facade.rb
+++ b/app/facades/tour_landmark_show_facade.rb
@@ -9,7 +9,7 @@ class TourLandmarkShowFacade
   end
 
   def picture
-    @_picture ||= google_service.get_picture(landmark.photo_reference)
+    landmark.photo_reference
   end
   
   def tour
@@ -18,11 +18,5 @@ class TourLandmarkShowFacade
 
   def recordings
     @_recordings ||= tour.recordings_for_landmark(landmark)
-  end
-
-  private
-
-  def google_service
-    @_google_service ||= GoogleService.new
   end
 end

--- a/app/views/tours/index.html.erb
+++ b/app/views/tours/index.html.erb
@@ -3,6 +3,7 @@
   <% @tours.each do |tour| %>
     <div class='tour-list'>
       <%= render partial: 'shared/voting_arrows', object: tour %>
+      <img src=<%= tour.landmarks.first.photo_reference %> alt="<%= tour.title %> thumbnail" class="tour-thumb">
       <div class='tour-box'>
         <%= link_to tour.title, tour_path(tour), class: 'tour-info'%><br>
         Creator: <%= link_to tour.user.display_name, user_path(tour.user), class: 'tour-info' %><br>

--- a/app/views/tours/index.html.erb
+++ b/app/views/tours/index.html.erb
@@ -3,7 +3,9 @@
   <% @tours.each do |tour| %>
     <div class='tour-list'>
       <%= render partial: 'shared/voting_arrows', object: tour %>
-      <img src=<%= tour.landmarks.first.photo_reference %> alt="<%= tour.title %> thumbnail" class="tour-thumb">
+      <% if tour.landmarks.first %>
+        <img src=<%= tour.landmarks.first.photo_reference %> alt="<%= tour.title %> thumbnail" class="tour-thumb">
+      <% end %>
       <div class='tour-box'>
         <%= link_to tour.title, tour_path(tour), class: 'tour-info'%><br>
         Creator: <%= link_to tour.user.display_name, user_path(tour.user), class: 'tour-info' %><br>

--- a/app/views/user/dashboard/index.html.erb
+++ b/app/views/user/dashboard/index.html.erb
@@ -31,7 +31,9 @@
   <% @user.tours.each do |tour| %>
     <div class='tour-list'>
       <%= render partial: 'shared/voting_arrows', object: tour %>
-      <img src=<%= tour.landmarks.first.photo_reference %> alt="<%= tour.title %> thumbnail" class="tour-thumb">
+      <% if tour.landmarks.first %>
+        <img src=<%= tour.landmarks.first.photo_reference %> alt="<%= tour.title %> thumbnail" class="tour-thumb">
+      <% end %>
       <div class='tour-box'>
         <%= link_to tour.title, tour_path(tour) %>
       </div>

--- a/app/views/user/dashboard/index.html.erb
+++ b/app/views/user/dashboard/index.html.erb
@@ -31,6 +31,7 @@
   <% @user.tours.each do |tour| %>
     <div class='tour-list'>
       <%= render partial: 'shared/voting_arrows', object: tour %>
+      <img src=<%= tour.landmarks.first.photo_reference %> alt="<%= tour.title %> thumbnail" class="tour-thumb">
       <div class='tour-box'>
         <%= link_to tour.title, tour_path(tour) %>
       </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -22,6 +22,7 @@
   <% @user.tours.each do |tour| %>
     <div class='tour-list'>
       <%= render partial: 'shared/voting_arrows', object: tour %>
+      <img src=<%= tour.landmarks.first.photo_reference %> alt="<%= tour.title %> thumbnail" class="tour-thumb">
       <div class='tour-box'>
         <%= link_to tour.title, tour_path(tour) %>
       </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -22,7 +22,9 @@
   <% @user.tours.each do |tour| %>
     <div class='tour-list'>
       <%= render partial: 'shared/voting_arrows', object: tour %>
-      <img src=<%= tour.landmarks.first.photo_reference %> alt="<%= tour.title %> thumbnail" class="tour-thumb">
+      <% if tour.landmarks.first %>
+        <img src=<%= tour.landmarks.first.photo_reference %> alt="<%= tour.title %> thumbnail" class="tour-thumb">
+      <% end %>
       <div class='tour-box'>
         <%= link_to tour.title, tour_path(tour) %>
       </div>

--- a/lib/tasks/add_landmarks.rake
+++ b/lib/tasks/add_landmarks.rake
@@ -96,6 +96,8 @@ namespace :landmarks do
       landmark = Landmark.find_or_initialize_by(place_id: details[:place_id])
       puts "Found/created Landmark resource for #{details[:name]}"
       unless landmark.md5_hash == hashed_details
+        photo_ref = details[:photos].first[:photo_reference]
+        thumb_url = GoogleService.new.get_picture(photo_ref)
         landmark.update(
           name: details[:name],
           address: details[:formatted_address],
@@ -104,7 +106,7 @@ namespace :landmarks do
           lat: details[:geometry][:location][:lat],
           long: details[:geometry][:location][:lng],
           website: details[:website],
-          photo_reference: details[:photos].first[:photo_reference]
+          photo_reference: thumb_url
         )
         puts "Updated Landmark resource for #{details[:name]}"
       end

--- a/spec/factories/landmarks.rb
+++ b/spec/factories/landmarks.rb
@@ -8,6 +8,6 @@ FactoryBot.define do
     category { "park" }
     place_id { Faker::Crypto.sha1 }
     website { Faker::Internet.url }
-    photo_reference { 'CmRaAAAA58Iy6Em8ucPC_-OCxKTJ-p7YKDBUQ4mgVZj4qlFN6j2JhXKSfteprF-Ckca73TjXaYUtNk-trEbhBCWoUcWWsO42KRap_rlw4teWz4hqBU57sAoTl3-myl_4xjOw3LmBEhBTUAINq_SeOPXlwudc8ccKGhSH-pCQxOO6rRE-O1zFKPW1-h3OqA' }
+    photo_reference { 'https://lh3.googleusercontent.com/p/AF1QipMSRaKMGzPSpTxaKRFQaakq9McSixbA7lIyBtqg' }
   end
 end

--- a/spec/features/landmarks/show_spec.rb
+++ b/spec/features/landmarks/show_spec.rb
@@ -10,7 +10,7 @@ feature 'landmark show', :vcr do
     long: -104.981784,
     website: 'https://www.denvergov.org/content/denvergov/en/denver-parks-and-recreation.html',
     place_id: 'ChIJISHlw9l-bIcRl-J_-5IVSN8',
-    photo_reference: 'CmRaAAAA0DaL7ahs9-s43r1B5UgJDfY-PWSTiU4IaIGZXneIhnL9VoLasfdjb8uILVT2fpv3itbylY_ag0rfjDCNkgQfX7BbukpZYFyZkcyxt5QzpS4T-0jsU6i-yukAWcoplJ79EhAuUtUH8AmRk8vestSiHYHBGhR1RIVab8DqQ39GMus178M4aHepwQ'
+    photo_reference: 'https://lh3.googleusercontent.com/p/AF1QipMSRaKMGzPSpTxaKRFQaakq9McSixbA7lIyBtqg'
     ) }
 
   let(:user) { create(:user) }

--- a/spec/features/user/dashboard/index_spec.rb
+++ b/spec/features/user/dashboard/index_spec.rb
@@ -13,7 +13,7 @@ feature 'user dashboard', :vcr do
       long: -104.981784,
       website: 'https://www.denvergov.org/content/denvergov/en/denver-parks-and-recreation.html',
       place_id: 'ChIJISHlw9l-bIcRl-J_-5IVSN8',
-      photo_reference: 'CmRaAAAA0DaL7ahs9-s43r1B5UgJDfY-PWSTiU4IaIGZXneIhnL9VoLasfdjb8uILVT2fpv3itbylY_ag0rfjDCNkgQfX7BbukpZYFyZkcyxt5QzpS4T-0jsU6i-yukAWcoplJ79EhAuUtUH8AmRk8vestSiHYHBGhR1RIVab8DqQ39GMus178M4aHepwQ'
+      photo_reference: 'https://lh3.googleusercontent.com/p/AF1QipMSRaKMGzPSpTxaKRFQaakq9McSixbA7lIyBtqg'
     )
 
     @recording1 = create(:recording, user: @user1, landmark: @landmark)


### PR DESCRIPTION
**Changes proposed in this pull request:**
 - Changes the `photo_reference` attribute of `Landmark` to be the image URL instead of Google's identifier for the photo -- refactor the rake task to run `GoogleService#get_picture` instead of calling it in the facade
 - Displays a square thumbnail for the tour (the image for the first landmark on the tour) on the tours index, user show page, and user dashboard
 
Resolves #93 
 
**The following checks have been completed:**
 - [x] Tested my new feature(s) as well as any feasible edge cases (if possible)
 - [x] Checked `coverage/index.html` - did not add any new code that's not covered by testing (if possible)
 - [x] Merged in the latest master to my branch with `git pull origin master` & resolved merge conflicts
 - [x] Ran `rails db:migrate`
 - [x] Ran the test suite - all tests are passing (or maybe skipped)
 - [x] Poked around in localhost with a small screen size - my new features (as well as basic functionality of the site) are working
 
**Notes:**
 - Everyone (including Heroku) will need to run `rake landmarks:all` and `rails db:seed` for this branch to work