### PR TITLE
Update md5hash for new photo_reference format

### DIFF
--- a/app/models/landmark.rb
+++ b/app/models/landmark.rb
@@ -18,8 +18,7 @@ class Landmark < ApplicationRecord
       #{self.address}
       #{self.phone_number}
       #{self.category}
-      #{self.website}
-      #{self.photo_reference}"
+      #{self.website}"
     )
   end
 end

--- a/lib/tasks/add_landmarks.rake
+++ b/lib/tasks/add_landmarks.rake
@@ -82,16 +82,16 @@ namespace :landmarks do
   def create_or_update_landmark(details, type)
     puts "Starting Landmark resource update for #{details[:name]}"
     unless details[:photos].nil?
-      hashed_details = Digest::MD5.hexdigest(
-        "#{details[:name]}
-        #{details[:place_id]}
-        #{details[:formatted_address]}
-        #{details[:formatted_phone_number]}
-        #{type}
-        #{details[:website]}
-        #{details[:photos].first[:photo_reference]}"
-      )
-
+      hashed_details = "TODO: delete"
+      # TODO: undo comment after everyone (including Heroku) has run the script above
+      # hashed_details = Digest::MD5.hexdigest(
+      #   "#{details[:name]}
+      #   #{details[:place_id]}
+      #   #{details[:formatted_address]}
+      #   #{details[:formatted_phone_number]}
+      #   #{type}
+      #   #{details[:website]}
+      # )
 
       landmark = Landmark.find_or_initialize_by(place_id: details[:place_id])
       puts "Found/created Landmark resource for #{details[:name]}"


### PR DESCRIPTION
**Changes proposed in this pull request:**
 - Change `Landmark.md5_hash` to disclude the photo_reference (since it's not directly what google provides anymore). 
 - Make the rake task update all landmarks for now.
 
**The following checks have been completed:**
 - [x] Tested my new feature(s) as well as any feasible edge cases (if possible)
 - [x] Checked `coverage/index.html` - did not add any new code that's not covered by testing (if possible)
 - [x] Merged in the latest master to my branch with `git pull origin master` & resolved merge conflicts
 - [x] Ran `rails db:migrate`
 - [x] Ran the test suite - all tests are passing (or maybe skipped)
 - [x] Poked around in localhost with a small screen size - my new features (as well as basic functionality of the site) are working